### PR TITLE
Redirect index.html to www.teamsuman.org and add 404 handler

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,9 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Redirecting to www.teamsuman.org...</title>
-  <meta http-equiv="refresh" content="0; url=https://www.teamsuman.org/">
   <link rel="canonical" href="https://www.teamsuman.org/">
-  <script>window.location.replace("https://www.teamsuman.org/");</script>
+  <script>
+    // Preserve the path/query when redirecting sub-URLs
+    var path = window.location.pathname + window.location.search + window.location.hash;
+    window.location.replace("https://www.teamsuman.org" + path);
+  </script>
 </head>
 <body>
   <p>This site has permanently moved to <a href="https://www.teamsuman.org/">www.teamsuman.org</a>. If you are not redirected automatically, please click the link.</p>


### PR DESCRIPTION
## Summary
This PR replaces the entire website content with redirect pages, migrating the site from the current domain to www.teamsuman.org. The main index.html has been converted to a simple redirect page, and a new 404.html handler has been added to preserve URL paths during the migration.

## Key Changes
- **index.html**: Replaced ~860 lines of full website content (navbar, hero carousel, research sections, team info, footer, etc.) with a minimal HTML redirect page that:
  - Uses `<meta http-equiv="refresh">` for automatic redirection
  - Includes a JavaScript fallback redirect
  - Provides a manual link for users with JavaScript disabled
  
- **404.html**: Added new redirect handler that:
  - Preserves the original request path, query parameters, and hash fragments
  - Redirects all 404 errors to the corresponding URL on www.teamsuman.org
  - Includes fallback link for manual navigation

## Implementation Details
- Both redirect pages include canonical links pointing to www.teamsuman.org
- The 404 handler uses `window.location.pathname + window.location.search + window.location.hash` to maintain URL structure during migration
- Minimal HTML structure ensures fast loading and broad browser compatibility
- Graceful fallback with visible links for users with JavaScript disabled

https://claude.ai/code/session_01E3uCLx8fraPCLmyggckM2w